### PR TITLE
Make isFocusable a tracked property

### DIFF
--- a/addon/components/navigation-narrator.js
+++ b/addon/components/navigation-narrator.js
@@ -8,6 +8,7 @@ export default class NavigationNarratorComponent extends Component {
   @service router;
 
   @tracked isSkipLinkFocused = false;
+  @tracked isFocusable = true;
 
   get skipLink() {
     return this.args.skipLink ?? true;
@@ -30,9 +31,6 @@ export default class NavigationNarratorComponent extends Component {
 
   constructor() {
     super(...arguments);
-
-    // set the skip link properties
-    this.isFocusable = true;
 
     // focus on the navigation message after render
     this.router.on('didTransition', () => {


### PR DESCRIPTION
I was checking the code for the `navigation-narrator` component and it seems that the `isFocusable` property is used in the template but is not marked as tracked.