### PR TITLE
drop support for node 12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [ '12', '14', '16' ]
+        node: [ '14', '16' ]
         ember-try-scenario:
           - ember-lts-3.24
           - ember-lts-3.28

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@embroider/compat": "1.8.0"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "14.* || >= 16"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
If merged, this PR drops support for Node 12. 

Once merged, a new major will be released. 