### PR TITLE
Remove route handler when un-rendering.

### DIFF
--- a/tests/integration/components/navigation-narrator-test.js
+++ b/tests/integration/components/navigation-narrator-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, focus, blur, settled } from '@ember/test-helpers';
+import { render, clearRender, focus, blur, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { MockTransition } from '../../helpers/mocks';
 
@@ -80,6 +80,18 @@ module('Integration | Component | navigation-narrator', function (hooks) {
       await settled();
 
       assert.dom('#ember-a11y-refocus-nav-message').isFocused();
+    });
+
+    test('it does not error if element is removed before focus', async function (assert) {
+      assert.expect(0); // no assertions here, just making sure the test runs w/o erroring
+      let router = this.owner.lookup('service:router');
+
+      await render(hbs`<NavigationNarrator />`);
+      await clearRender();
+
+      router.trigger('routeDidChange', new MockTransition());
+
+      await settled();
     });
 
     test('it accepts custom change-detection logic', async function (assert) {


### PR DESCRIPTION
We were running into this error in CI:

```
Cannot read properties of null (reading 'focus')
Source:
TypeError: Cannot read properties of null (reading 'focus')
    at NavigationNarratorComponent.<anonymous> (http://localhost:7357/assets/vendor.js:113983:73)
    at invoke (http://localhost:7357/assets/vendor.js:59751:16)
    at Queue.flush (http://localhost:7357/assets/vendor.js:59642:13)
    at DeferredActionQueues.flush (http://localhost:7357/assets/vendor.js:59839:21)
    at Backburner._end (http://localhost:7357/assets/vendor.js:60371:34)
    at Backburner._boundAutorunEnd (http://localhost:7357/assets/vendor.js:60040:14)
```

This PR fixes that by using ember destroyables to remove the route change handler when the `NavigationNarrator` component is un-rendered.

The testing solution is a bit strange - I was able to recreate the issue, but there's not really anything to assert. I ended up using `assert.expect(0)` with the idea being that the test completing without error checks for the behavior we want.

Without the change the added test does fail:

![CleanShot 2022-09-29 at 15 01 33](https://user-images.githubusercontent.com/39469/193131361-2fed09e4-d7c5-4773-a3c4-8d2907b4b1a4.png)

