### PR TITLE
bugfix: cancel timer in the destroyable

### DIFF
--- a/addon/components/navigation-narrator.js
+++ b/addon/components/navigation-narrator.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { registerDestructor } from '@ember/destroyable';
 import { inject as service } from '@ember/service';
-import { schedule } from '@ember/runloop';
+import { schedule, cancel } from '@ember/runloop';
 import { tracked } from '@glimmer/tracking';
 import { defaultValidator } from 'ember-a11y-refocus';
 
@@ -10,6 +10,8 @@ export default class NavigationNarratorComponent extends Component {
   @service router;
 
   @tracked isSkipLinkFocused = false;
+
+  timer = null;
 
   get skipLink() {
     return this.args.skipLink ?? true;
@@ -41,6 +43,8 @@ export default class NavigationNarratorComponent extends Component {
     this.router.on('routeDidChange', this.onRouteChange);
 
     registerDestructor(this, () => {
+      cancel(this.timer);
+      this.timer = null;
       this.router.off('routeDidChange', this.onRouteChange);
     });
   }
@@ -53,7 +57,8 @@ export default class NavigationNarratorComponent extends Component {
       return;
     }
 
-    schedule('afterRender', this, function () {
+    this.timer = schedule('afterRender', this, function () {
+      this.timer = null;
       document.body.querySelector('#ember-a11y-refocus-nav-message').focus();
     });
   }


### PR DESCRIPTION
So I thought I suitable reproduced my error in https://github.com/ember-a11y/ember-a11y-refocus/pull/347 but it turns out the timing issue in my application was more subtle than that. We were still seeing the same issue, so the order of execution must be:

route change handler -> schedule afterRender -> component unrenders -> route handler removed -> afterRender runs w/o the element -> error about no element to `focus()`

This PR _also_ cancels the `schedule`'d execution and we're no longer seeing the issue in our test suite. My issue though is this: I don't know how to recreate this situation in a test - any ideas or pointers?