### PR TITLE
Add support for queryParam flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ export default class ApplicationController extends Controller {
 
 The validator function:
 
-- Receives a [Transition](https://api.emberjs.com/ember/release/classes/Transition) object containing information about the source and destination routes
-- Should return `true` if refocusing should occur, otherwise `false`
+* Receives a [Transition](https://api.emberjs.com/ember/release/classes/Transition) object containing information about the source and destination routes
+* Should return `true` if refocusing should occur, otherwise `false`
 
 If you wish to extend the default behavior (rather than completely replacing it), you can import the default validator like so:
 
@@ -94,10 +94,11 @@ If you wish to extend the default behavior (rather than completely replacing it)
 Additional Options
 ------------------------------------------------------------------------------
 
-* `skipLink` - pass `{{false}}` if you do not want to implement a skip link.
+* `skipLink` - pass `{{false}}` if you do not want to implement a bypass block/skip link.
 * `skipTo` - pass a specific element ID that should receive focus on skip.
 * `skipText` - customize the text passed in the skip link. Defaults to "Skip to main content".
 * `navigationText` - customize the text passed as the navigation message. Defaults to "The page navigation is complete. You may now navigate the page content as you wish."
+* `excludeAllQueryParams` - pass `{{true}}` if you want to exclude all query params from the route change check.
 
 FastBoot
 ------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -94,11 +94,13 @@ If you wish to extend the default behavior (rather than completely replacing it)
 Additional Options
 ------------------------------------------------------------------------------
 
+All of these are optional and have default values.
+
 * `skipLink` - pass `{{false}}` if you do not want to implement a bypass block/skip link.
-* `skipTo` - pass a specific element ID that should receive focus on skip.
-* `skipText` - customize the text passed in the skip link. Defaults to "Skip to main content".
-* `navigationText` - customize the text passed as the navigation message. Defaults to "The page navigation is complete. You may now navigate the page content as you wish."
-* `excludeAllQueryParams` - pass `{{true}}` if you want to exclude all query params from the route change check.
+* `skipTo` - pass a specific element ID that should receive focus on skip. Defaults to `#main`.
+* `skipText` - customize the text passed in the skip link. Defaults to `Skip to main content`.
+* `navigationText` - customize the text passed as the navigation message. Defaults to `The page navigation is complete. You may now navigate the page content as you wish`.
+* `excludeAllQueryParams` - pass `{{true}}` if you want to exclude all query params from the route change check/focus management. Really shouldn't do this, but you might be upgrading an older app and need this for a little bit, or you are using QPs in a specific way and would like to otherwise benefit from the accessibility options in this addon. If you only need to exclude _some_ QPs, use the custom validator function instead.
 
 FastBoot
 ------------------------------------------------------------------------------

--- a/addon/components/navigation-narrator.js
+++ b/addon/components/navigation-narrator.js
@@ -108,17 +108,11 @@ export default class NavigationNarratorComponent extends Component {
     let shouldFocus;
     this.transition = transition; // We need to do this because we can't pass an argument to a getter
 
-    if (this.excludeAllQueryParams === true) {
-      if (this.hasQueryParams === true) {
-        return;
-      } else {
-        // it does not matter, there aren't any query params
-        shouldFocus = this.routeChangeValidator(transition);
-      }
-    } else {
-      // excludeAllQueryParams is false, carry on
-      shouldFocus = this.routeChangeValidator(transition);
+    if (this.excludeAllQueryParams && this.hasQueryParams) {
+      return;
     }
+
+    shouldFocus = this.routeChangeValidator(transition);
 
     // leaving this here for now because maybe it needs to be used in a custom validator function
     if (!shouldFocus) {

--- a/addon/components/navigation-narrator.js
+++ b/addon/components/navigation-narrator.js
@@ -64,13 +64,13 @@ export default class NavigationNarratorComponent extends Component {
   }
 
   /*
-   * @param includeAllQueryParams
+   * @param excludeAllQueryParams
    * @type {boolean}
    * @description Whether or not to include all query params in definition of a route transition. If you want to include/exclude _some_ query params, the routeChangeValidator function should be used instead.
-   * @default true
+   * @default false
    */
-  get includeAllQueryParams() {
-    return this.args.includeAllQueryParams ?? true;
+  get excludeAllQueryParams() {
+    return this.args.excludeAllQueryParams ?? false;
   }
 
   /*
@@ -93,6 +93,35 @@ export default class NavigationNarratorComponent extends Component {
 
   constructor() {
     super(...arguments);
+    this.router.on('routeWillChange', (transition) => {
+      let { to: toRouteInfo, from: fromRouteInfo } = transition;
+      if (fromRouteInfo) {
+        console.log(`Transitioning from -> ${fromRouteInfo.name}`);
+        console.log(`From QPs: ${JSON.stringify(fromRouteInfo.queryParams)}`);
+        console.log(`From Params: ${JSON.stringify(fromRouteInfo.params)}`);
+      }
+
+      if (toRouteInfo) {
+        console.log(`to -> ${toRouteInfo.name}`);
+        console.log(`To QPs: ${JSON.stringify(toRouteInfo.queryParams)}`);
+        console.log(`To Params: ${JSON.stringify(toRouteInfo.params)}`);
+      }
+    });
+
+    this.router.on('routeDidChange', (transition) => {
+      let { to: toRouteInfo, from: fromRouteInfo } = transition;
+      if (fromRouteInfo) {
+        console.log(`Transitioned from -> ${fromRouteInfo.name}`);
+        console.log(`From QPs: ${JSON.stringify(fromRouteInfo.queryParams)}`);
+        console.log(`From Params: ${JSON.stringify(fromRouteInfo.params)}`);
+      }
+
+      if (toRouteInfo) {
+        console.log(`to -> ${toRouteInfo.name}`);
+        console.log(`To QPs: ${JSON.stringify(toRouteInfo.queryParams)}`);
+        console.log(`To Params: ${JSON.stringify(toRouteInfo.params)}`);
+      }
+    });
 
     this.router.on('routeDidChange', this.onRouteChange);
 
@@ -108,31 +137,19 @@ export default class NavigationNarratorComponent extends Component {
     let shouldFocus;
     this.transition = transition; // We need to do this because we can't pass an argument to a getter
 
-    // if `includeAllQueryParams` is true, we should do the route transition and manage focus
-    if (this.includeAllQueryParams) {
-      shouldFocus = this.routeChangeValidator(transition);
-      console.log('shouldFocus 1 this is regular thing', shouldFocus);
-    } else if (
-      // if `includeAllQueryParams` is false BUT there are no query params, we should still manage focus
-      this.includeAllQueryParams === false &&
-      this.hasQueryParams === false
-    ) {
-      shouldFocus = this.routeChangeValidator(transition);
-      console.log('shouldFocus 2 still should manage focus', shouldFocus);
-    } else if (
-      this.includeAllQueryParams === false &&
-      this.hasQueryParams === true
-    ) {
-      // if `includeAllQueryParams` is false and there are query params, we should NOT manage focus
-      console.log(
-        'shouldFocus 3 should not transition or managefocus',
-        shouldFocus
-      );
-      return;
+    if (this.excludeAllQueryParams === true) {
+      if (this.hasQueryParams === true) {
+        return;
+      } else {
+        // it does not matter, there aren't any query params
+        shouldFocus = this.routeChangeValidator(transition);
+      }
     } else {
-      return;
+      // excludeAllQueryParams is false, carry on
+      shouldFocus = this.routeChangeValidator(transition);
     }
 
+    // leaving this here for now because maybe it needs to be used in a custom validator function
     if (!shouldFocus) {
       return;
     }

--- a/addon/components/navigation-narrator.js
+++ b/addon/components/navigation-narrator.js
@@ -93,35 +93,6 @@ export default class NavigationNarratorComponent extends Component {
 
   constructor() {
     super(...arguments);
-    this.router.on('routeWillChange', (transition) => {
-      let { to: toRouteInfo, from: fromRouteInfo } = transition;
-      if (fromRouteInfo) {
-        console.log(`Transitioning from -> ${fromRouteInfo.name}`);
-        console.log(`From QPs: ${JSON.stringify(fromRouteInfo.queryParams)}`);
-        console.log(`From Params: ${JSON.stringify(fromRouteInfo.params)}`);
-      }
-
-      if (toRouteInfo) {
-        console.log(`to -> ${toRouteInfo.name}`);
-        console.log(`To QPs: ${JSON.stringify(toRouteInfo.queryParams)}`);
-        console.log(`To Params: ${JSON.stringify(toRouteInfo.params)}`);
-      }
-    });
-
-    this.router.on('routeDidChange', (transition) => {
-      let { to: toRouteInfo, from: fromRouteInfo } = transition;
-      if (fromRouteInfo) {
-        console.log(`Transitioned from -> ${fromRouteInfo.name}`);
-        console.log(`From QPs: ${JSON.stringify(fromRouteInfo.queryParams)}`);
-        console.log(`From Params: ${JSON.stringify(fromRouteInfo.params)}`);
-      }
-
-      if (toRouteInfo) {
-        console.log(`to -> ${toRouteInfo.name}`);
-        console.log(`To QPs: ${JSON.stringify(toRouteInfo.queryParams)}`);
-        console.log(`To Params: ${JSON.stringify(toRouteInfo.params)}`);
-      }
-    });
 
     this.router.on('routeDidChange', this.onRouteChange);
 

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -30,12 +30,12 @@ html {
 body {
   font-size: 1rem;
   line-height: 1.2;
-  font-family: Roboto, sans-serif;
+  font-family: system-ui, Roboto, sans-serif;
   padding: 0
 }
 
 main {
-  padding: .5rem 1rem;
+  padding: 0.5rem 1rem;
   min-height: 90vh;
 }
 
@@ -62,4 +62,10 @@ nav ul li a:hover {
 
 footer {
   padding: 0.5rem 1rem;
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+}
+footer a {
+  padding: 0.5rem;
 }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -14,4 +14,5 @@
 </main>
 <footer>
   <p><a href="https://github.com/ember-a11y/ember-a11y-refocus">GitHub Repo</a></p>
+  <p><a href="/tests">Tests (for development)</a></p>
 </footer>

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -5,7 +5,7 @@ module.exports = function (environment) {
     modulePrefix: 'dummy',
     environment,
     rootURL: '/',
-    locationType: 'auto',
+    locationType: 'history',
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build

--- a/tests/integration/components/navigation-narrator-test.js
+++ b/tests/integration/components/navigation-narrator-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, clearRender, focus, blur, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { MockTransition } from '../../helpers/mocks';
+import { MockTransition, MockRouteInfo } from '../../helpers/mocks';
 
 module('Integration | Component | navigation-narrator', function (hooks) {
   setupRenderingTest(hooks);
@@ -54,7 +54,7 @@ module('Integration | Component | navigation-narrator', function (hooks) {
       assert.dom('.ember-a11y-refocus-skip-link').hasText('Skip to content');
     });
 
-    test('it shows/hides for keyboard users', async function (assert) {
+    test('it shows/hides the bypass block/skip link for keyboard users', async function (assert) {
       await render(hbs`<NavigationNarrator />`);
 
       assert.dom('.ember-a11y-refocus-skip-link').doesNotHaveClass('active');
@@ -70,7 +70,7 @@ module('Integration | Component | navigation-narrator', function (hooks) {
   });
 
   module('on routeDidChange', function () {
-    test('it takes focus', async function (assert) {
+    test('it handles focus', async function (assert) {
       let router = this.owner.lookup('service:router');
 
       await render(hbs`<NavigationNarrator />`);
@@ -108,6 +108,86 @@ module('Integration | Component | navigation-narrator', function (hooks) {
       await settled();
 
       assert.dom('#ember-a11y-refocus-nav-message').isNotFocused();
+    });
+
+    test('it transitions routes with query params and manages focus if `includeAllQueryParams` is true (default)', async function (assert) {
+      let router = this.owner.lookup('service:router');
+
+      await render(hbs`<NavigationNarrator />`);
+
+      router.trigger(
+        'routeDidChange',
+        new MockTransition({
+          from: new MockRouteInfo({
+            name: 'biscuit',
+            params: { id: 'hobnob' },
+            parent: new MockRouteInfo({
+              name: 'biscuits',
+              queryParams: { region: 'amer' },
+              parent: new MockRouteInfo({
+                name: 'application',
+              }),
+            }),
+          }),
+          to: new MockRouteInfo({
+            name: 'biscuit',
+            params: { id: 'hobnob' },
+            parent: new MockRouteInfo({
+              name: 'biscuits',
+              queryParams: { region: 'apac' },
+              parent: new MockRouteInfo({
+                name: 'application',
+              }),
+            }),
+          }),
+        })
+      );
+
+      await settled();
+
+      assert.dom('#ember-a11y-refocus-nav-message').isFocused();
+    });
+
+    test('includeAllQueryParams is false, queryParams exist', async function (assert) {
+      let router = this.owner.lookup('service:router');
+
+      await render(
+        hbs`<NavigationNarrator @includeAllQueryParams={{false}} />`
+      );
+
+      // router.trigger('routeDidChange', new MockTransition());
+      router.trigger(
+        'routeDidChange',
+        new MockTransition({
+          from: new MockRouteInfo({
+            name: 'biscuit',
+            params: { id: 'hobnob' },
+            queryParams: { region: 'amer' },
+          }),
+          to: new MockRouteInfo({
+            name: 'biscuit',
+            params: { id: 'hobnob' },
+            queryParams: { region: 'apac' },
+          }),
+        })
+      );
+
+      await settled();
+
+      assert.dom('#ember-a11y-refocus-nav-message').isNotFocused();
+    });
+
+    test('includeAllQueryParams is false, but queryParams do not exist', async function (assert) {
+      let router = this.owner.lookup('service:router');
+
+      await render(
+        hbs`<NavigationNarrator @includeAllQueryParams={{false}} />`
+      );
+      router.trigger('routeDidChange', new MockTransition());
+
+      await settled();
+
+      assert.dom('#ember-a11y-refocus-nav-message').isFocused();
     });
   });
 });

--- a/tests/integration/components/navigation-narrator-test.js
+++ b/tests/integration/components/navigation-narrator-test.js
@@ -110,7 +110,7 @@ module('Integration | Component | navigation-narrator', function (hooks) {
       assert.dom('#ember-a11y-refocus-nav-message').isNotFocused();
     });
 
-    test('it transitions routes with query params and manages focus if `includeAllQueryParams` is true (default)', async function (assert) {
+    test('it transitions routes with query params and manages focus if `excludeAllQueryParams` is false (default)', async function (assert) {
       let router = this.owner.lookup('service:router');
 
       await render(hbs`<NavigationNarrator />`);
@@ -121,24 +121,12 @@ module('Integration | Component | navigation-narrator', function (hooks) {
           from: new MockRouteInfo({
             name: 'biscuit',
             params: { id: 'hobnob' },
-            parent: new MockRouteInfo({
-              name: 'biscuits',
-              queryParams: { region: 'amer' },
-              parent: new MockRouteInfo({
-                name: 'application',
-              }),
-            }),
+            queryParams: { region: 'amer' },
           }),
           to: new MockRouteInfo({
             name: 'biscuit',
             params: { id: 'hobnob' },
-            parent: new MockRouteInfo({
-              name: 'biscuits',
-              queryParams: { region: 'apac' },
-              parent: new MockRouteInfo({
-                name: 'application',
-              }),
-            }),
+            queryParams: { region: 'apac' },
           }),
         })
       );
@@ -148,12 +136,10 @@ module('Integration | Component | navigation-narrator', function (hooks) {
       assert.dom('#ember-a11y-refocus-nav-message').isFocused();
     });
 
-    test('includeAllQueryParams is false, queryParams exist', async function (assert) {
+    test('excludeAllQueryParams is true, queryParams exist, should not manage focus', async function (assert) {
       let router = this.owner.lookup('service:router');
 
-      await render(
-        hbs`<NavigationNarrator @includeAllQueryParams={{false}} />`
-      );
+      await render(hbs`<NavigationNarrator @excludeAllQueryParams={{true}} />`);
 
       // router.trigger('routeDidChange', new MockTransition());
       router.trigger(
@@ -177,12 +163,10 @@ module('Integration | Component | navigation-narrator', function (hooks) {
       assert.dom('#ember-a11y-refocus-nav-message').isNotFocused();
     });
 
-    test('includeAllQueryParams is false, but queryParams do not exist', async function (assert) {
+    test('excludeAllQueryParams is true, but queryParams do not exist, manage focus', async function (assert) {
       let router = this.owner.lookup('service:router');
 
-      await render(
-        hbs`<NavigationNarrator @includeAllQueryParams={{false}} />`
-      );
+      await render(hbs`<NavigationNarrator @excludeAllQueryParams={{true}} />`);
       router.trigger('routeDidChange', new MockTransition());
 
       await settled();


### PR DESCRIPTION
If merged, this PR adds a conditional for `excludeAllQueryParams` which is set to `false` by default. If set to `true` then it should check for the presence of queryParams and if QPs are present, don't manage the route transition or focus.

- updated README
- extra tests have been added
- a little extra link to browser tests has been added to the dummy app for dev env convenience

Tests passing:
![CleanShot 2024-06-04 at 13 37 43@2x](https://github.com/ember-a11y/ember-a11y-refocus/assets/4587451/f04ef0a2-2802-404e-9dec-1bb77575c946)
