### PR TITLE
Add the `ember-try` scenarios back into the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request: {}
 
 jobs:
   test:
@@ -23,7 +23,40 @@ jobs:
         run: npm install -g pnpm
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm i
 
       - name: Run tests
         run: pnpm test
+
+  try-scenarios:
+    name: ${{ matrix.try-scenario }}
+    runs-on: ubuntu-latest
+    needs: 'test'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        try-scenario:
+          - ember-lts-3.28
+          - ember-lts-4.12
+          - ember-release
+          - embroider-safe
+          - embroider-optimized
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+      
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Install dependencies
+        run: pnpm i
+
+      - name: Run Tests
+        run: pnpm ember try:one ${{ matrix.try-scenario }}

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,9 +1,11 @@
 'use strict';
 
 const getChannelURL = require('ember-source-channel-url');
+const { embroiderSafe, embroiderOptimized } = require('@embroider/test-setup');
 
 module.exports = async function () {
   return {
+    command: 'pnpm test:ember',
     useYarn: false,
     usePnpm: true,
     scenarios: [
@@ -12,14 +14,6 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': '3.28.12',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-4.8',
-        npm: {
-          devDependencies: {
-            'ember-source': '4.8.6',
           },
         },
       },
@@ -33,13 +27,33 @@ module.exports = async function () {
       },
       {
         name: 'ember-release',
-        allowedToFail: true,
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('release'),
           },
         },
+        allowedToFail: true,
       },
+      {
+        name: 'ember-beta',
+        npm: {
+          devDependencies: {
+            'ember-source': await getChannelURL('beta'),
+          },
+        },
+        allowedToFail: true,
+      },
+      {
+        name: 'ember-canary',
+        npm: {
+          devDependencies: {
+            'ember-source': await getChannelURL('canary'),
+          },
+        },
+        allowedToFail: true,
+      },
+      embroiderSafe({ allowedToFail: true }),
+      embroiderOptimized({ allowedToFail: true }),
     ],
   };
 };


### PR DESCRIPTION
If merged, this PR re-adds the ember-try scenarios back into the `ci.yml` file. 

Current release is allowed to fail for the time being, but an issue has been filed: #372 