### PR TITLE
Upgrade to `ember-source` 4.12.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@babel/plugin-proposal-async-generator-functions": "^7.20.7",
     "@babel/plugin-proposal-class-static-block": "^7.21.0",
     "@ember/optional-features": "^2.0.0",
+    "@ember/string": "^3.1.1",
     "@ember/test-helpers": "^2.6.0",
     "@embroider/compat": "1.9.0",
     "@embroider/core": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "ember-page-title": "^7.0.0",
     "ember-qunit": "^5.1.5",
     "ember-resolver": "^8.0.3",
-    "ember-source": "4.9.2",
+    "ember-source": "^4.12.4",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^4.0.0",
     "ember-try": "2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ devDependencies:
     version: 2.1.0
   '@ember/test-helpers':
     specifier: ^2.6.0
-    version: 2.9.4(@babel/core@7.24.6)(ember-source@4.9.2)
+    version: 2.9.4(@babel/core@7.24.6)(ember-source@4.12.4)
   '@embroider/compat':
     specifier: 1.9.0
     version: 1.9.0(@embroider/core@1.9.0)
@@ -92,8 +92,8 @@ devDependencies:
     specifier: ^8.0.3
     version: 8.1.0(@babel/core@7.24.6)
   ember-source:
-    specifier: 4.9.2
-    version: 4.9.2(@babel/core@7.24.6)(@glimmer/component@1.1.2)(webpack@5.91.0)
+    specifier: ^4.12.4
+    version: 4.12.4(@babel/core@7.24.6)(@glimmer/component@1.1.2)(webpack@5.91.0)
   ember-source-channel-url:
     specifier: ^3.0.0
     version: 3.0.0
@@ -1437,7 +1437,7 @@ packages:
       - supports-color
     dev: true
 
-  /@ember/test-helpers@2.9.4(@babel/core@7.24.6)(ember-source@4.9.2):
+  /@ember/test-helpers@2.9.4(@babel/core@7.24.6)(ember-source@4.12.4):
     resolution: {integrity: sha512-z+Qs1NYWyIVDmrY6WdmOS5mdG1lJ5CFfzh6dRhLfs9lq45deDaDrVNcaCYhnNeJZTvUBK2XR2SvPcZm0RloXdA==}
     engines: {node: 10.* || 12.* || 14.* || 15.* || >= 16.*}
     peerDependencies:
@@ -1445,13 +1445,13 @@ packages:
     dependencies:
       '@ember/test-waiters': 3.1.0
       '@embroider/macros': 1.16.2
-      '@embroider/util': 1.13.1(ember-source@4.9.2)
+      '@embroider/util': 1.13.1(ember-source@4.12.4)
       broccoli-debug: 0.6.5
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 6.3.0
       ember-destroyable-polyfill: 2.0.3(@babel/core@7.24.6)
-      ember-source: 4.9.2(@babel/core@7.24.6)(@glimmer/component@1.1.2)(webpack@5.91.0)
+      ember-source: 4.12.4(@babel/core@7.24.6)(@glimmer/component@1.1.2)(webpack@5.91.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/environment-ember-loose'
@@ -1668,7 +1668,7 @@ packages:
       resolve: 1.22.8
     dev: true
 
-  /@embroider/util@1.13.1(ember-source@4.9.2):
+  /@embroider/util@1.13.1(ember-source@4.12.4):
     resolution: {integrity: sha512-MRbs2FPO4doQ31YHIYk+QKChEs7k15aTsMk8QmO4eKiuQq9OT0sr1oasObZyGB8cVVbr29WWRWmsNirxzQtHIg==}
     engines: {node: 12.* || 14.* || >= 16}
     peerDependencies:
@@ -1684,7 +1684,7 @@ packages:
       '@embroider/macros': 1.16.2
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
-      ember-source: 4.9.2(@babel/core@7.24.6)(@glimmer/component@1.1.2)(webpack@5.91.0)
+      ember-source: 4.12.4(@babel/core@7.24.6)(@glimmer/component@1.1.2)(webpack@5.91.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5942,6 +5942,50 @@ packages:
       - webpack
     dev: true
 
+  /ember-auto-import@2.7.3(webpack@5.91.0):
+    resolution: {integrity: sha512-EQzStGYxNvTPYWCFh0X57HFAzAvA2rHHRgBeWNDKHQ/rENNlHw0c0e0i1XebwEfv+yGHOodE4dN+f/mrYkQXLw==}
+    engines: {node: 12.* || 14.* || >= 16}
+    dependencies:
+      '@babel/core': 7.24.6(supports-color@8.1.1)
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.24.6)
+      '@babel/plugin-proposal-decorators': 7.24.6(@babel/core@7.24.6)
+      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.24.6)
+      '@babel/plugin-transform-class-static-block': 7.24.6(@babel/core@7.24.6)
+      '@babel/preset-env': 7.24.6(@babel/core@7.24.6)
+      '@embroider/macros': 1.16.2
+      '@embroider/shared-internals': 2.6.1
+      babel-loader: 8.3.0(@babel/core@7.24.6)(webpack@5.91.0)
+      babel-plugin-ember-modules-api-polyfill: 3.5.0
+      babel-plugin-ember-template-compilation: 2.2.5
+      babel-plugin-htmlbars-inline-precompile: 5.3.1
+      babel-plugin-syntax-dynamic-import: 6.18.0
+      broccoli-debug: 0.6.5
+      broccoli-funnel: 3.0.8
+      broccoli-merge-trees: 4.2.0
+      broccoli-plugin: 4.0.7
+      broccoli-source: 3.0.1
+      css-loader: 5.2.7(webpack@5.91.0)
+      debug: 4.3.4(supports-color@8.1.1)
+      fs-extra: 10.1.0
+      fs-tree-diff: 2.0.1
+      handlebars: 4.7.8
+      js-string-escape: 1.0.1
+      lodash: 4.17.21
+      mini-css-extract-plugin: 2.9.0(webpack@5.91.0)
+      minimatch: 3.1.2
+      parse5: 6.0.1
+      resolve: 1.22.8
+      resolve-package-path: 4.0.3
+      semver: 7.6.2
+      style-loader: 2.0.0(webpack@5.91.0)
+      typescript-memoize: 1.1.1
+      walk-sync: 3.0.0
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+      - webpack
+    dev: true
+
   /ember-cli-babel-plugin-helpers@1.1.1:
     resolution: {integrity: sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -6404,7 +6448,7 @@ packages:
       '@ember/test-helpers': ^2.4.0
       qunit: ^2.13.0
     dependencies:
-      '@ember/test-helpers': 2.9.4(@babel/core@7.24.6)(ember-source@4.9.2)
+      '@ember/test-helpers': 2.9.4(@babel/core@7.24.6)(ember-source@4.12.4)
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 3.0.2
       common-tags: 1.8.2
@@ -6460,8 +6504,8 @@ packages:
       - encoding
     dev: true
 
-  /ember-source@4.9.2(@babel/core@7.24.6)(@glimmer/component@1.1.2)(webpack@5.91.0):
-    resolution: {integrity: sha512-tbrJidtp8WlDxrnpLZ7iXDHUvcw7pqvzRXV+0xtfLiEibk3KEyqD80ssnSZrl3Nz8/Rt3DhQESn2W2LVm0zQrg==}
+  /ember-source@4.12.4(@babel/core@7.24.6)(@glimmer/component@1.1.2)(webpack@5.91.0):
+    resolution: {integrity: sha512-HUlNAY+qr/Jm4c/5E11n5w6IvLY7Rr4DxmFv/0LZ3R5LqDSubM1jEmny5zDjOfadMa4pawoCmFFWXVeJEXwppg==}
     engines: {node: '>= 14.*'}
     peerDependencies:
       '@glimmer/component': ^1.1.2
@@ -6471,6 +6515,7 @@ packages:
       '@ember/edition-utils': 1.2.0
       '@glimmer/component': 1.1.2(@babel/core@7.24.6)
       '@glimmer/vm-babel-plugins': 0.84.2(@babel/core@7.24.6)
+      '@simple-dom/interface': 1.4.0
       babel-plugin-debug-macros: 0.3.4(@babel/core@7.24.6)
       babel-plugin-filter-imports: 4.0.0
       broccoli-concat: 4.2.5
@@ -6479,7 +6524,7 @@ packages:
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 4.2.0
       chalk: 4.1.2
-      ember-auto-import: 2.4.2(webpack@5.91.0)
+      ember-auto-import: 2.7.3(webpack@5.91.0)
       ember-cli-babel: 7.26.11
       ember-cli-get-component-path-option: 1.0.0
       ember-cli-is-package-missing: 1.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ devDependencies:
   '@ember/optional-features':
     specifier: ^2.0.0
     version: 2.1.0
+  '@ember/string':
+    specifier: ^3.1.1
+    version: 3.1.1
   '@ember/test-helpers':
     specifier: ^2.6.0
     version: 2.9.4(@babel/core@7.24.6)(ember-source@4.12.4)
@@ -1433,6 +1436,15 @@ packages:
       inquirer: 7.3.3
       mkdirp: 1.0.4
       silent-error: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@ember/string@3.1.1:
+    resolution: {integrity: sha512-UbXJ+k3QOrYN4SRPHgXCqYIJ+yWWUg1+vr0H4DhdQPTy8LJfyqwZ2tc5uqpSSnEXE+/1KopHBE5J8GDagAg5cg==}
+    engines: {node: 12.* || 14.* || >= 16}
+    dependencies:
+      ember-cli-babel: 7.26.11
     transitivePeerDependencies:
       - supports-color
     dev: true


### PR DESCRIPTION
If merged, this PR upgrades `ember-source` to 4.12.4 and adds the `@ember/string` package to resolve some deprecation warnings. 