### PR TITLE
Protected Against Empty transition.to

### DIFF
--- a/addon/components/navigation-narrator.js
+++ b/addon/components/navigation-narrator.js
@@ -82,7 +82,7 @@ export default class NavigationNarratorComponent extends Component {
   get hasQueryParams() {
     if (
       Object.keys(this.transition.from?.queryParams || {}).length ||
-      Object.keys(this.transition.to.queryParams).length > 0
+      Object.keys(this.transition.to?.queryParams || {}).length > 0
     ) {
       return true;
     } else {
@@ -108,7 +108,7 @@ export default class NavigationNarratorComponent extends Component {
     this.transition = transition; // We need to do this because we can't pass an argument to a getter
 
     // add a check to see if it's the same route
-    let hasSameRoute = this.transition.from?.name === this.transition.to.name;
+    let hasSameRoute = this.transition.from?.name === this.transition.to?.name;
 
     if (this.excludeAllQueryParams && this.hasQueryParams && hasSameRoute) {
       return;


### PR DESCRIPTION
When a transition is aborted (and maybe at other times) transition.to is null and needs to be guarded against just like transition.from.

@MelSumner This fixes an issue created by #379 which pops up in our app during authentication with `ember-simple-auth`. There are probably other ways to hit this as well.