### PR TITLE
Simplified importing styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,31 +18,13 @@ Single-Page Applications(SPAs) use `pushState` to allow portions of the page to 
 
 Since `pushState` does nothing to inform the browser--and, by extent, the screen reader--that new content is present, the screen-reader user has no way of knowing that new content exists, or that navigation to a new page was successful. Additionally, focus remains where it was, instead of being reset in a predictable fashion.
 
-## FAQs
-
-### What about async data loading?
-
-Async data can be loaded as it normally would be. Since this addon does not use `aria-live`, it won't interfere with or compete with other loading states. This will only give the user with a screen reader a message that the route (URL) has changed, and place the focus where they expect it to be (reset to the top left of the page).
-
-### What if I want to put focus somewhere specific in the app flow?
-
-Since this will run before other content, focus can be programmatically moved by the developer to go somewhere else. The message should still read out, and is findable by users with screen readers.
-
-Compatibility
-------------------------------------------------------------------------------
-
-* Ember.js v4.12 or above
-* Node.js v18 or above
-
-Installation
-------------------------------------------------------------------------------
+## Installation
 
 ```bash
 ember install ember-a11y-refocus
 ```
 
-Usage
-------------------------------------------------------------------------------
+## Usage
 
 - Insert `<NavigationNarrator/>` into your application.hbs file, preferably inside of a `<header>` element.
 - Next, add `id="main"` to the primary content element in your application (hopefully a `<main>` element).
@@ -101,7 +83,6 @@ const app = new EmberApp(defaults, {
 @use "navigation-narrator.css";
 ```
 
-
 ### Customizing the definition of a route change
 
 This addon provides support for custom definitions of which route changes should trigger refocusing behavior.
@@ -127,8 +108,8 @@ export default class ApplicationController extends Controller {
 
 The validator function:
 
-* Receives a [Transition](https://api.emberjs.com/ember/release/classes/Transition) object containing information about the source and destination routes
-* Should return `true` if refocusing should occur, otherwise `false`
+- Receives a [Transition](https://api.emberjs.com/ember/release/classes/Transition) object containing information about the source and destination routes
+- Should return `true` if refocusing should occur, otherwise `false`
 
 If you wish to extend the default behavior (rather than completely replacing it), you can import the default validator like so:
 
@@ -147,19 +128,17 @@ If you wish to extend the default behavior (rather than completely replacing it)
  }
  ```
 
-Additional Options
-------------------------------------------------------------------------------
+## Additional Options
 
 All of these are optional and have default values.
 
-* `skipLink` - pass `{{false}}` if you do not want to implement a bypass block/skip link.
-* `skipTo` - pass a specific element ID that should receive focus on skip. Defaults to `#main`.
-* `skipText` - customize the text passed in the skip link. Defaults to `Skip to main content`.
-* `navigationText` - customize the text passed as the navigation message. Defaults to `The page navigation is complete. You may now navigate the page content as you wish`.
-* `excludeAllQueryParams` - pass `{{true}}` if you want to exclude all query params from the route change check/focus management. Really shouldn't do this, but you might be upgrading an older app and need this for a little bit, or you are using QPs in a specific way and would like to otherwise benefit from the accessibility options in this addon. If you only need to exclude _some_ QPs, use the custom validator function instead.
+- `skipLink` - pass `{{false}}` if you do not want to implement a bypass block/skip link.
+- `skipTo` - pass a specific element ID that should receive focus on skip. Defaults to `#main`.
+- `skipText` - customize the text passed in the skip link. Defaults to `Skip to main content`.
+- `navigationText` - customize the text passed as the navigation message. Defaults to `The page navigation is complete. You may now navigate the page content as you wish`.
+- `excludeAllQueryParams` - pass `{{true}}` if you want to exclude all query params from the route change check/focus management. Really shouldn't do this, but you might be upgrading an older app and need this for a little bit, or you are using QPs in a specific way and would like to otherwise benefit from the accessibility options in this addon. If you only need to exclude _some_ QPs, use the custom validator function instead.
 
-FastBoot
-------------------------------------------------------------------------------
+## FastBoot
 
 With FastBoot, you'll want to guard the `<NavigationNarrator />` from rendering. Like so:
 
@@ -171,12 +150,25 @@ With FastBoot, you'll want to guard the `<NavigationNarrator />` from rendering.
 
 Where `this.fastboot` is the fastboot service injected in the application controller.
 
-Contributing
-------------------------------------------------------------------------------
+## FAQs
+
+### What about async data loading?
+
+Async data can be loaded as it normally would be. Since this addon does not use `aria-live`, it won't interfere with or compete with other loading states. This will only give the user with a screen reader a message that the route (URL) has changed, and place the focus where they expect it to be (reset to the top left of the page).
+
+### What if I want to put focus somewhere specific in the app flow?
+
+Since this will run before other content, focus can be programmatically moved by the developer to go somewhere else. The message should still read out, and is findable by users with screen readers.
+
+## Compatibility
+
+- Ember.js v4.12 or above
+- Node.js v18 or above
+
+## Contributing
 
 Contributions are welcome.
 
-License
-------------------------------------------------------------------------------
+## License
 
 This project is licensed under the [MIT License](LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -54,34 +54,55 @@ import { NavigationNarrator } from 'ember-a11y-refocus';
 
 Template Registry is available for loose mode users:
 
-```js
+```ts
 import type EmberA11yRefocusRegistry from 'ember-a11y-refocus/template-registry';
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry
-    extends EmberA11yRefocusRegistry{
-  }
+    extends EmberA11yRefocusRegistry {}
 }
 ```
 
-Minimal CSS is provided to style the skip link and navigation message. You can override these styles in your app's CSS.
+Minimal CSS is provided to style the skip link and navigation message.
+
+```diff
+/* app/app.ts */
++ import 'ember-a11y-refocus/styles.css';
++
+import Application from '@ember/application';
+import loadInitializers from 'ember-load-initializers';
+import Resolver from 'ember-resolver';
+
+import config from './config/environment';
+
+export default class App extends Application {
+  modulePrefix = config.modulePrefix;
+  podModulePrefix = config.podModulePrefix;
+  Resolver = Resolver;
+}
+
+loadInitializers(App, config.modulePrefix);
+```
+
+<details>
+
+<summary>Use Sass?</summary>
 
 ```js
 // ember-cli-build.js
 const app = new EmberApp(defaults, {
-  const app = new EmberApp(defaults, {
-      sassOptions: {
-      includePaths: ['node_modules/ember-a11y-refocus/dist/styles'],
-    },
-  });
+  sassOptions: {
+    includePaths: ['node_modules/ember-a11y-refocus/dist/styles'],
+  },
 });
 ```
 
 ```scss
-// app.scss
-
+/* app/styles/app.scss */
 @use "navigation-narrator.css";
 ```
+
+</details>
 
 ### Customizing the definition of a route change
 

--- a/addon/package.json
+++ b/addon/package.json
@@ -25,7 +25,8 @@
       "types": "./declarations/*.d.ts",
       "default": "./dist/*.js"
     },
-    "./addon-main.js": "./addon-main.cjs"
+    "./addon-main.js": "./addon-main.cjs",
+    "./styles.css": "./dist/styles/navigation-narrator.css"
   },
   "typesVersions": {
     "*": {


### PR DESCRIPTION
Patches #390, which began requiring end-users to import the addon's styles.

By re-exporting the addon's CSS file, end-users can easily import the file and migrate to `v5`. I think the `README` should highlight the usual/base case of vanilla CSS, rather than Sass.

Tested the changes on https://github.com/ijlee2/ember-container-query/pull/263.

<img width="900" alt="" src="https://github.com/user-attachments/assets/ba0917fa-2c42-4d02-a9c7-f342774f1019" />


