### PR TITLE
allow github code highlighting for gjs example

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Example:
 
 Gjs/Gts:
 
-```gts
+```gjs
 import { NavigationNarrator } from 'ember-a11y-refocus';
 
 <template>


### PR DESCRIPTION
apparently the `gts` code highliting isn't done yet in github, but the example in the readme isn't using types so swapping it to `gjs` fixes it