### PR TITLE
add the ability to import styles from bundlers that care about exports

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -21,6 +21,7 @@
       "types": "./declarations/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./styles": "./dist/styles/navigation-narrator.css",
     "./*": {
       "types": "./declarations/*.d.ts",
       "default": "./dist/*.js"


### PR DESCRIPTION
This is needed if you want to be able to import the styles in Vite, we should have a discussion about what this should look like going forward before we add something to the docs but for now this unblocks us using the provided styles in Vite 👍 

Note: you can see this PR working correctly here: https://github.com/ember-learn/rfcs-app/pull/19
