### PR TITLE
Revert "add the ability to import styles from bundlers that care about exports"

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -21,7 +21,6 @@
       "types": "./declarations/index.d.ts",
       "default": "./dist/index.js"
     },
-    "./styles": "./dist/styles/navigation-narrator.css",
     "./*": {
       "types": "./declarations/*.d.ts",
       "default": "./dist/*.js"


### PR DESCRIPTION
Reverts ember-a11y/ember-a11y-refocus#417

It turns out that we don't need this because it was already done in https://github.com/ember-a11y/ember-a11y-refocus/pull/415 🙈 